### PR TITLE
Qerrormessage bug fix

### DIFF
--- a/node_launcher/gui/network_buttons/lnd_wallet_layout.py
+++ b/node_launcher/gui/network_buttons/lnd_wallet_layout.py
@@ -107,7 +107,8 @@ class LndWalletLayout(QGridLayout):
         elif 'connect failed' in details:
             pass
         else:
-            self.error_message.showMessage(details)
+            # self.error_message.showMessage(details)
+            QErrorMessage.showMessage(self.error_message, details)
             self.set_open_state()
 
     def set_unlock_state(self):

--- a/node_launcher/gui/network_buttons/lnd_wallet_layout.py
+++ b/node_launcher/gui/network_buttons/lnd_wallet_layout.py
@@ -107,8 +107,8 @@ class LndWalletLayout(QGridLayout):
         elif 'connect failed' in details:
             pass
         else:
-            # self.error_message.showMessage(details)
-            QErrorMessage.showMessage(self.error_message, details)
+            self.error_message.showMessage(details)
+            # QErrorMessage.showMessage(self.error_message, details)
             self.set_open_state()
 
     def set_unlock_state(self):

--- a/node_launcher/gui/network_buttons/lnd_wallet_layout.py
+++ b/node_launcher/gui/network_buttons/lnd_wallet_layout.py
@@ -93,14 +93,21 @@ class LndWalletLayout(QGridLayout):
         if details is None:
             return
         details = details.lower()
+
+        # The Wallet Unlocker gRPC service disappears from LND's API
+        # after the wallet is unlocked (or created/recovered)
         if 'unknown service lnrpc.walletunlocker' in details:
             self.set_open_state()
+
+        # User needs to create a new wallet
         elif 'wallet not found' in details:
             self.set_create_recover_state()
+
+        # Todo: add logging for debugging
         elif 'connect failed' in details:
             pass
         else:
-            QErrorMessage(self).showMessage(details)
+            self.error_message.showMessage(details)
             self.set_open_state()
 
     def set_unlock_state(self):

--- a/tests/test_gui/test_network_buttons/test_lnd_wallet_layout.py
+++ b/tests/test_gui/test_network_buttons/test_lnd_wallet_layout.py
@@ -32,7 +32,8 @@ class TestLndWalletLayout(object):
                            lnd_wallet_layout: LndWalletLayout,
                            qtbot: QTest):
         lnd_wallet_layout.handle_lnd_poll('unknown gRPC error detail')
-        error_message_patch.showMessage.assert_called()
+        # error_message_patch.showMessage.assert_called()
+        lnd_wallet_layout.error_message.showMessage.assert_called()
 
     def test_unlock_wallet(self,
                            seed_dialog_patch: MagicMock,

--- a/tests/test_gui/test_network_buttons/test_lnd_wallet_layout.py
+++ b/tests/test_gui/test_network_buttons/test_lnd_wallet_layout.py
@@ -22,6 +22,18 @@ def lnd_wallet_layout() -> LndWalletLayout:
 @patch('node_launcher.gui.network_buttons.lnd_wallet_layout.QThreadPool')
 @patch('node_launcher.gui.network_buttons.lnd_wallet_layout.SeedDialog')
 class TestLndWalletLayout(object):
+    def test_handle_lnd_poll_error_message(self,
+                           seed_dialog_patch: MagicMock,
+                           thread_pool_patch: MagicMock,
+                           input_dialog_patch: MagicMock,
+                           error_message_patch: MagicMock,
+                           lnd_client_patch: MagicMock,
+                           keyring_patch: MagicMock,
+                           lnd_wallet_layout: LndWalletLayout,
+                           qtbot: QTest):
+        lnd_wallet_layout.handle_lnd_poll('unknown gRPC error detail')
+        error_message_patch.showMessage.assert_called()
+
     def test_unlock_wallet(self,
                            seed_dialog_patch: MagicMock,
                            thread_pool_patch: MagicMock,


### PR DESCRIPTION
In the https://github.com/lightning-power-users/node-launcher/commit/9c8726f5e1388e6a11f8b26706ddae3e43b3638c commit, I modified the 2 following files : 
* [lnd_wallet_layout.py](https://github.com/lightning-power-users/node-launcher/compare/master...BobleChinois:qerrormessage_bug_fix?expand=1#diff-4fd8dd6257b0e8a441b17d1a5d6315e8): replaced the faulty line with `self.error_message.showMessage(details)`
* [test_lnd_wallet_layout.py](https://github.com/lightning-power-users/node-launcher/compare/master...BobleChinois:qerrormessage_bug_fix?expand=1#diff-4c12f1c6d15e52be50b7417e3183ca09): this is the unit test you wrote, I didn't make any change.

I tried run the tests, and found out the new test will generate the following error:
```
self = <test_lnd_wallet_layout.TestLndWalletLayout object at 0x7f4134474eb8>
seed_dialog_patch = <MagicMock name='SeedDialog' id='139918026653312'>
thread_pool_patch = <MagicMock name='QThreadPool' id='139918026702576'>
input_dialog_patch = <MagicMock name='QInputDialog' id='139918026710936'>
error_message_patch = <MagicMock name='QErrorMessage' id='139918026743880'>
lnd_client_patch = <MagicMock name='LndClient' id='139918026752296'>
keyring_patch = <MagicMock name='keyring' id='139918026764752'>
lnd_wallet_layout = <node_launcher.gui.network_buttons.lnd_wallet_layout.LndWalletLayout object at 0x7f4134460808>
qtbot = <pytestqt.qtbot.QtBot object at 0x7f413446bef0>

    def test_handle_lnd_poll_error_message(self,
                           seed_dialog_patch: MagicMock,
                           thread_pool_patch: MagicMock,
                           input_dialog_patch: MagicMock,
                           error_message_patch: MagicMock,
                           lnd_client_patch: MagicMock,
                           keyring_patch: MagicMock,
                           lnd_wallet_layout: LndWalletLayout,
                           qtbot: QTest):
        lnd_wallet_layout.handle_lnd_poll('unknown gRPC error detail')
>       error_message_patch.showMessage.assert_called()

tests/test_gui/test_network_buttons/test_lnd_wallet_layout.py:35: 
```
I'm not too sure what's wrong, but in commit https://github.com/lightning-power-users/node-launcher/commit/ace62e7361834b99733a9994f2d905de7ef00f47 I tried using the solution you proposed first `QErrorMessage.showMessage(self.error_message, details)`, and there's no error in the unit test. 
Except if you have an idea of what was wrong and want to try something else, if we agree to go with the fix as it is now I can add a third commit just to remove the commented out line and we will be ready to merge.