### PR TITLE
Disabling Zap QRCode

### DIFF
--- a/node_launcher/gui/network_buttons/zap_layout.py
+++ b/node_launcher/gui/network_buttons/zap_layout.py
@@ -33,17 +33,17 @@ Manually open the Zap Desktop application first
         self.open_zap_desktop_button = QtWidgets.QPushButton('Configure Zap Desktop')
         self.open_zap_desktop_button.clicked.connect(self.open_zap_desktop)
 
-        self.show_zap_qrcode_button = QtWidgets.QPushButton('Show QR Code')
-        self.show_zap_qrcode_button.clicked.connect(self.show_zap_qrcode)
+        # self.show_zap_qrcode_button = QtWidgets.QPushButton('Show QR Code')
+        # self.show_zap_qrcode_button.clicked.connect(self.show_zap_qrcode)
 
         self.addWidget(self.section_name, column_span=columns)
-        self.addWidget(self.open_zap_desktop_button)
-        self.addWidget(self.show_zap_qrcode_button, same_row=True, column=2)
+        self.addWidget(self.open_zap_desktop_button, column_span=columns)
+        # self.addWidget(self.show_zap_qrcode_button, same_row=True, column=2)
         self.addWidget(HorizontalLine(), column_span=columns)
 
     def set_button_state(self):
         self.open_zap_desktop_button.setEnabled(self.node_set.lnd.is_unlocked)
-        self.show_zap_qrcode_button.setEnabled(self.node_set.lnd.is_unlocked)
+        # self.show_zap_qrcode_button.setEnabled(self.node_set.lnd.is_unlocked)
 
     def open_zap_desktop(self):
         # This should soon be replaced with using the get_lndconnect_url method

--- a/tests/test_gui/test_network_buttons/test_zap_layout.py
+++ b/tests/test_gui/test_network_buttons/test_zap_layout.py
@@ -34,7 +34,7 @@ class TestZapLayout(object):
         qtbot.mouseClick(zap_layout.open_zap_desktop_button, Qt.LeftButton)
         get_deprecated_lndconnect_url_patch.assert_called_once()
         webbrowser_patch.open.assert_called_once()
-
+'''
     def test_show_zap_qrcode(self,
                              qlabel_patch: MagicMock,
                              qpixmap_patch: MagicMock,
@@ -46,3 +46,4 @@ class TestZapLayout(object):
         qtbot.mouseClick(zap_layout.show_zap_qrcode_button, Qt.LeftButton)
         get_qrcode_img_patch.assert_called_once()
         qpixmap_patch.assert_called_once()
+'''


### PR DESCRIPTION
The latest changes to lnd config which changed the host from `0.0.0.0` to `localhost` and the removal of the `tlsextraip` property from conf broke this button.

The current implementation of the QRCode button was also less than ideal for now since it only worked inside the same local network.

We should think about how to implement that properly, also allowing one to connect to the lnd node over the internet.

In the meantime, I'm disabling this button because it simply doesn't work.