### PR TITLE
Custom Ports and monitoring configuration files for Lnd and Bitcoin

### DIFF
--- a/node_launcher/gui/components/warning_text.py
+++ b/node_launcher/gui/components/warning_text.py
@@ -1,0 +1,9 @@
+from PySide2.QtCore import Qt
+from PySide2.QtWidgets import QLabel
+
+
+class WarningText(QLabel):
+    def __init__(self, text: str):
+        super().__init__()
+        self.setStyleSheet("QLabel {color: red}")
+        self.setText(text)

--- a/node_launcher/gui/network_buttons/__init__.py
+++ b/node_launcher/gui/network_buttons/__init__.py
@@ -2,3 +2,4 @@ from .joule_layout import JouleLayout
 from .lnd_wallet_layout import LndWalletLayout
 from .nodes_layout import NodesLayout
 from node_launcher.gui.network_buttons.advanced.zap_layout import ZapLayout
+from .restart_layout import RestartLayout

--- a/node_launcher/gui/network_buttons/advanced/cli_layout.py
+++ b/node_launcher/gui/network_buttons/advanced/cli_layout.py
@@ -1,4 +1,5 @@
 from PySide2.QtWidgets import QPushButton
+from PySide2.QtCore import QTimer
 
 from node_launcher.constants import BITCOIN_CLI_COMMANDS, LNCLI_COMMANDS
 from node_launcher.gui.cli.cli import CliWidget
@@ -13,9 +14,11 @@ class CliLayout(QGridLayout):
     copy_lncli: CopyButton
     copy_bitcoin_cli: CopyButton
     node_set: NodeSet
+    timer = QTimer
 
     def __init__(self, node_set: NodeSet):
         super(CliLayout, self).__init__()
+        self.timer = QTimer(self.parentWidget())
         self.node_set = node_set
 
         self.lncli_widget = CliWidget(
@@ -46,7 +49,20 @@ class CliLayout(QGridLayout):
         self.addWidget(self.section_name, column_span=columns)
         self.addWidget(self.open_bitcoin_cli_button)
         self.addWidget(self.open_lncli_button, same_row=True, column=columns)
+        self.horizontal_line = HorizontalLine()
+        self.addWidget(self.horizontal_line, column_span=columns)
+        self.horizontal_line.hide()
+        self.node_set.bitcoin.file.file_watcher.fileChanged.connect(self.check_restart_required)
+        self.node_set.lnd.file.file_watcher.fileChanged.connect(self.check_restart_required)
+        self.timer.start(1000)
+        self.timer.timeout.connect(self.check_restart_required)
 
     def set_button_state(self):
         self.copy_bitcoin_cli.button.setEnabled(self.node_set.bitcoin.running)
         self.copy_lncli.button.setEnabled(self.node_set.lnd.is_unlocked)
+
+    def check_restart_required(self):
+        if self.node_set.bitcoin.restart_required or self.node_set.lnd.restart_required:
+            self.horizontal_line.show()
+        else:
+            self.horizontal_line.hide()

--- a/node_launcher/gui/network_buttons/advanced/ports_layout.py
+++ b/node_launcher/gui/network_buttons/advanced/ports_layout.py
@@ -2,6 +2,7 @@ from node_launcher.gui.components.grid_layout import QGridLayout
 from node_launcher.gui.components.horizontal_line import HorizontalLine
 from node_launcher.gui.components.section_name import SectionName
 from node_launcher.gui.components.selectable_text import SelectableText
+from node_launcher.gui.components.warning_text import WarningText
 from node_launcher.node_set import NodeSet
 
 
@@ -56,3 +57,54 @@ class PortsLayout(QGridLayout):
             f'LND REST port: {self.node_set.lnd.rest_port}'
         )
         self.addWidget(self.rest_port)
+        self.bitcoin_restart_required = WarningText(
+            'Config file changed: Restart Bitcoin'
+        )
+        self.addWidget(self.bitcoin_restart_required)
+        self.bitcoin_restart_required.hide()
+        self.lnd_restart_required = WarningText(
+            'Config file changed: Restart LND'
+        )
+        self.addWidget(self.lnd_restart_required)
+        self.lnd_restart_required.hide()
+
+        self.node_set.bitcoin.file.file_watcher.fileChanged.connect(self.refresh_bitcoin_ports)
+        self.node_set.lnd.file.file_watcher.fileChanged.connect(self.refresh_lnd_ports)
+
+
+    def refresh_bitcoin_ports(self):
+        self.bitcoin_network_port.setText(
+            f'Bitcoin network peer port: {self.node_set.bitcoin.node_port}'
+        )
+        self.zmq_ports.setText(
+            f'Bitcoin ZMQ block/tx ports:'
+            f' {self.node_set.bitcoin.zmq_block_port}'
+            f'/{self.node_set.bitcoin.zmq_tx_port}'
+        )
+        self.rpc_port.setText(
+            f'Bitcoin RPC port: {self.node_set.bitcoin.rpc_port}'
+        )
+        self.check_restart_required()
+
+    def refresh_lnd_ports(self):
+        self.lnd_network_port.setText(
+            f'LND network peer port: {self.node_set.lnd.node_port}'
+        )
+        self.grpc_port.setText(
+            f'LND gRPC port: {self.node_set.lnd.grpc_port}'
+        )
+        self.rest_port.setText(
+            f'LND REST port: {self.node_set.lnd.rest_port}'
+        )
+        self.check_restart_required()
+
+    def check_restart_required(self):
+        if self.node_set.bitcoin.restart_required:
+            self.bitcoin_restart_required.show()
+        else:
+            self.bitcoin_restart_required.hide()
+
+        if self.node_set.lnd.restart_required:
+            self.lnd_restart_required.show()
+        else:
+            self.lnd_restart_required.hide()

--- a/node_launcher/gui/network_buttons/network_widget.py
+++ b/node_launcher/gui/network_buttons/network_widget.py
@@ -4,7 +4,7 @@ from PySide2.QtWidgets import QWidget
 from node_launcher.gui.components.grid_layout import QGridLayout
 from node_launcher.gui.network_buttons.advanced import CliLayout
 from node_launcher.node_set import NodeSet
-from . import JouleLayout, LndWalletLayout, NodesLayout, ZapLayout
+from . import JouleLayout, LndWalletLayout, NodesLayout, ZapLayout, RestartLayout
 
 
 class NetworkWidget(QWidget):
@@ -33,6 +33,9 @@ class NetworkWidget(QWidget):
 
         self.cli_layout = CliLayout(node_set=self.node_set)
         layout.addLayout(self.cli_layout, column_span=columns)
+
+        self.restart_layout = RestartLayout(node_set=self.node_set)
+        layout.addLayout(self.restart_layout)
 
         self.setLayout(layout)
 

--- a/node_launcher/gui/network_buttons/restart_layout.py
+++ b/node_launcher/gui/network_buttons/restart_layout.py
@@ -1,0 +1,45 @@
+from PySide2.QtCore import QTimer
+from node_launcher.gui.components.grid_layout import QGridLayout
+from node_launcher.gui.components.section_name import SectionName
+from node_launcher.node_set import NodeSet
+from node_launcher.gui.components.warning_text import WarningText
+
+
+class RestartLayout(QGridLayout):
+    node_set: NodeSet
+    timer = QTimer
+
+    def __init__(self, node_set: NodeSet):
+        super(RestartLayout, self).__init__()
+
+        self.timer = QTimer(self.parentWidget())
+
+        self.node_set = node_set
+        columns = 2
+
+        self.section_name = SectionName('Restart Required')
+        self.addWidget(self.section_name, column_span=columns)
+        self.bitcoin_restart_required = WarningText('Bitcoin: ')
+        self.lnd_restart_required = WarningText('Lnd: ')
+        self.addWidget(self.bitcoin_restart_required)
+        self.addWidget(self.lnd_restart_required, same_row=True, column=columns)
+        self.bitcoin_restart_required.hide()
+        self.lnd_restart_required.hide()
+        self.node_set.bitcoin.file.file_watcher.fileChanged.connect(self.check_restart_required)
+        self.node_set.lnd.file.file_watcher.fileChanged.connect(self.check_restart_required)
+        self.timer.start(1000)
+        self.timer.timeout.connect(self.check_restart_required)
+
+    def check_restart_required(self):
+        restart_required = self.node_set.bitcoin.restart_required or self.node_set.lnd.restart_required
+
+        self.bitcoin_restart_required.setText(f'Bitcoin: {self.node_set.bitcoin.restart_required}')
+        self.lnd_restart_required.setText(f'Lnd: {self.node_set.lnd.restart_required}')
+        if restart_required:
+            self.section_name.show()
+            self.bitcoin_restart_required.show()
+            self.lnd_restart_required.show()
+        else:
+            self.section_name.hide()
+            self.bitcoin_restart_required.hide()
+            self.lnd_restart_required.hide()

--- a/node_launcher/gui/settings/bitcoin_tab.py
+++ b/node_launcher/gui/settings/bitcoin_tab.py
@@ -46,8 +46,8 @@ class BitcoinTab(QWidget):
             lambda x: self.update_config('testnet', bool(x))
         )
         self.bitcoin_layout.addWidget(self.enable_testnet_widget)
-
         self.setLayout(self.bitcoin_layout)
+        self.bitcoin.file.file_watcher.fileChanged.connect(self.bitcoin_config_changed)
 
     def change_datadir(self, new_datadir: str):
         self.bitcoin.file['datadir'] = new_datadir
@@ -71,3 +71,13 @@ class BitcoinTab(QWidget):
             self.change_network.emit(TESTNET)
         elif name == 'testnet' and not state:
             self.change_network.emit(MAINNET)
+
+    def bitcoin_config_changed(self):
+        if self.bitcoin.file['testnet']:
+            self.enable_testnet_widget.blockSignals(True)
+            self.set_checked(self.enable_testnet_widget, True)
+            self.enable_testnet_widget.blockSignals(False)
+        else:
+            self.enable_testnet_widget.blockSignals(True)
+            self.set_checked(self.enable_testnet_widget, False)
+            self.enable_testnet_widget.blockSignals(False)

--- a/node_launcher/node_set/bitcoin.py
+++ b/node_launcher/node_set/bitcoin.py
@@ -386,7 +386,6 @@ class Bitcoin(object):
 
                 # Now check that values are the same
                 if found_in_old_config:
-                    print(f"Common {old_config[field]} vs {new_config[field]}")
                     if old_config[field] != new_config[field]:
                         return True
 
@@ -405,7 +404,6 @@ class Bitcoin(object):
 
                     # Now check that values are the same
                     if found_in_old_config:
-                        print(f"Testnet {old_config[field]} vs {new_config[field]}")
                         if old_config[field] != new_config[field]:
                             return True
 
@@ -431,7 +429,6 @@ class Bitcoin(object):
             return False
         elif self.running:
             # Network has changed and the node is running - Restart is required
-            print(f"{old_config_network} vs {new_config_network}")
             return True
 
         return False

--- a/tests/test_node_set/test_bitcoin.py
+++ b/tests/test_node_set/test_bitcoin.py
@@ -86,3 +86,22 @@ class TestBitcoinConfiguration(object):
         bitcoin.bitcoin_qt = MagicMock(return_value=command)
         result = bitcoin.launch()
         assert result.pid
+
+    def test_file_changed(self, bitcoin: Bitcoin):
+        bitcoin.file['rpcport'] = 8338
+        bitcoin.config_file_changed()
+        new_config = bitcoin.file.snapshot
+        bitcoin.running = False
+        assert bitcoin.rpc_port == new_config['rpcport'] == new_config['main.rpcport'] == 8338
+        assert bitcoin.restart_required == False
+        bitcoin.running = True
+        assert bitcoin.restart_required == True
+        bitcoin.file['port'] = 8336
+        bitcoin.config_file_changed()
+        new_config = bitcoin.file.snapshot
+        bitcoin.running = False
+        assert bitcoin.node_port == new_config['port'] == new_config['main.port'] == 8336
+        assert bitcoin.restart_required == False
+        bitcoin.running = True
+        assert bitcoin.restart_required == True
+

--- a/tests/test_node_set/test_lnd.py
+++ b/tests/test_node_set/test_lnd.py
@@ -46,3 +46,38 @@ class TestDirectoryConfiguration(object):
         lnd.lnd = MagicMock(return_value=command)
         result = lnd.launch()
         assert result
+
+    def test_bitcoin_file_changed(self, lnd: Lnd):
+        lnd.bitcoin.file['rpcport'] = 8338
+        lnd.bitcoin.running = False
+        lnd.bitcoin.config_file_changed()
+        lnd.bitcoin_config_file_changed()
+        new_config = lnd.file.snapshot
+        lnd.running = False
+        assert lnd.file['bitcoind.rpchost'] == new_config['bitcoind.rpchost'] == '127.0.0.1:8338'
+        assert lnd.restart_required == False
+        lnd.bitcoin.running = True
+        lnd.bitcoin.config_snapshot = lnd.bitcoin.file.snapshot
+        assert lnd.bitcoin.config_snapshot['rpcport'] == 8338
+        lnd.bitcoin.file['rpcport'] = 8340
+        lnd.bitcoin.config_file_changed()
+        lnd.bitcoin_config_file_changed()
+        new_config = lnd.file.snapshot
+        assert lnd.file['bitcoind.rpchost'] == new_config['bitcoind.rpchost'] == '127.0.0.1:8340'
+        assert lnd.restart_required == False
+        lnd.running = True
+        assert lnd.bitcoin.restart_required == True
+        assert lnd.restart_required == True
+
+    def test_file_changed(self, lnd: Lnd):
+        lnd.file['listen'] = '127.0.0.1:9739'
+        lnd.config_file_changed()
+        lnd.running = False
+        new_config = lnd.file.snapshot
+        assert lnd.node_port == new_config['listen'].split(':')[-1] == '9739'
+        assert lnd.restart_required == False
+        lnd.running = True
+        lnd.file['listen'] = '127.0.0.1:9741'
+        lnd.config_file_changed()
+        new_config = lnd.file.snapshot
+        assert lnd.node_port == new_config['listen'].split(':')[-1] == '9741'


### PR DESCRIPTION
This pull request aims to achieve the following:

- Allow for custom ports for the bitcoin and lnd nodes to be specified by the user by editing the configuration files
- Monitors the configuration files continuously for changes and alerts the user when changes are detected that required a restart of either node. 
- Ensures that wallets for testnet and mainnet are seperated in the bitcoin configuration file by specifying the test. prefix
- Ensures that the GUI is always kept in sync with manual changes are made by the user to the configuration files (lnd or bitcoin) outside of the application. 

Future work require:
Require further customization to support entirely seperate mainnet and testnet parameters to be specified in the same configuration file. 

Current assumptions:

- Only ports will be configured seperatly for Lnd and Bitcoin nodes, all other fields will be shared and do not require any prefix flags (i.e. test. or main.) Future revisions should add this functionality though. 

Tests were also added to test_bitcoin.py and test_lnd.py to verify whether changes are indeed picked up. 