### PR TITLE
Fix for Issue #228 (configuration file editing oddity)

### DIFF
--- a/node_launcher/services/configuration_file.py
+++ b/node_launcher/services/configuration_file.py
@@ -116,8 +116,9 @@ class ConfigurationFile(dict):
             lines = f.readlines()
         property_lines = [line_number for line_number, l in enumerate(lines)
                           if l.startswith(name)]
-        for property_line_index in property_lines:
-            lines.pop(property_line_index)
+        for property_line_index in reversed(property_lines):
+            for repeats in range(2):
+                lines.pop(property_line_index - 1)
         if value_list is not None:
             for value in value_list:
                 property_string = os.linesep + f'{name.strip()}={value.strip()}' + os.linesep

--- a/node_launcher/services/configuration_file.py
+++ b/node_launcher/services/configuration_file.py
@@ -117,7 +117,8 @@ class ConfigurationFile(dict):
         property_lines = [line_number for line_number, l in enumerate(lines)
                           if l.startswith(name)]
         for property_line_index in reversed(property_lines):
-            for repeats in range(2):
+            lines.pop(property_line_index)
+            if lines[property_line_index - 1] == os.linesep:
                 lines.pop(property_line_index - 1)
         if value_list is not None:
             for value in value_list:


### PR DESCRIPTION
This is a fix for #228 that works by reorganising the way the configuration file is parsed into the list object within the `ConfigurationFile` class. As it is now, new properties get popped off just once if they already exist, but are parsed as 2 objects from the file ('\n', '<property-line\n>').

This fix works by also popping off two objects as well to include the extra `\n` parsed. It traverses the list in reverse order so as to not affect the index positions of later items in the list when looping through to pop them off.

_Note: This fixes a problem that manifests in Linux environments where `os.linesep` gives you a `\n` symbol that gets parsed back in as a separate list item when reading from the file using `f.readlines()`._
**~To determine on review, whether this behaviour is the same in other environments.~**