### PR TITLE
Fix bitcoin datadir path checker

### DIFF
--- a/node_launcher/node_set/bitcoin.py
+++ b/node_launcher/node_set/bitcoin.py
@@ -33,8 +33,10 @@ class Bitcoin(object):
         self.running = False
         self.process = None
 
-        if (not os.path.exists(self.file['datadir'])
-                or self.file['datadir'] is None):
+        try:
+            if not os.path.exists(self.file['datadir']) or self.file['datadir'] is None:
+                self.autoconfigure_datadir()
+        except TypeError:
             self.autoconfigure_datadir()
 
         if 'bitcoin.conf' in os.listdir(self.file['datadir']):


### PR DESCRIPTION
Catch Exception where searching for non-existent key (datadir) would
return 'None' which, when passed to os.path.exists() caused an exception
and was causing multiple test failures for me on two machines.

Signed-off-by: willcl-ark <will8clark@gmail.com>