### PR TITLE
Readme Install python3.7-dev - Fix for Issue #378

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Install Python3.7+
 
 macOS: `brew install python3 dbus dbus-glib`
 
-Linux: `sudo apt install python3.7-venv libdbus-glib-1-dev`
+Linux: `sudo apt install python3.7-venv libdbus-glib-1-dev python3.7-dev`
 
 For Windows see https://medium.com/@pierre_rochard/node-launcher-developer-setup-on-windows-5ba6e0fbb38a
 


### PR DESCRIPTION
Fix for issue #378 on the main repo. Issue was that Python.h was not found while attempting to install psutil with pip3.7. It required python3.7-dev to also be installed on your linux distro.